### PR TITLE
QuantumPioneer Initial Release (v1.0.0)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, release/*]
   workflow_dispatch:
 
 concurrency:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ job_1, job_2, job_3 = fglp(FNAME, get=("gibbs", "scf"))
 | SCF Energy | `scf` | list[float] | 1/job |
 | Vibrational Frequencies | `frequencies` | list[float] | 1/job |
 | Frequency Modes | `frequency_modes` | list[list[float]] | 1/job |
+| NMR Shielding | `nmr_shielding` | list[list[int, float, float]] | 1/job |
 | Standardized xyz coords | `std_xyz` | list[list[float]] | 1/step/job |
 | Input xyz coords | `xyz` | list[list[float]] | 1/step/job |
 | Standardized forces | `std_forces` | list[list[float]] | 1/step/job |

--- a/README.md
+++ b/README.md
@@ -82,7 +82,13 @@ $3$ E0 for wavefunction methods <br>
 | Final Single Point Energy | `energy` | float | 1/job |
 | Input xyz coords | `input_coordinates` | list[list[float]] | 1/job |
 
-$1$ ignores milliseconds <br>
+#### Orca
+
+| Quantity | Key | Type | Frequency |
+| -------- | --- | ---- | --------- |
+| Area | `area` | float | 1/job |
+| Volume | `volume` | float | 1/job |
+| Energy | `energy` | float | 1/job |
 
 ## How much fast-ly-er?
 `FastLogfileParser` uses REGEX and only REGEX to retrieve data from logfiles, spending as much time in Python's excellent C-based REGEX library as possible.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ $3$ E0 for wavefunction methods <br>
 | Final Single Point Energy | `energy` | float | 1/job |
 | Input xyz coords | `input_coordinates` | list[list[float]] | 1/job |
 
-#### Orca
+#### COSMO
 
 | Quantity | Key | Type | Frequency |
 | -------- | --- | ---- | --------- |

--- a/fastlogfileparser/cosmors/__init__.py
+++ b/fastlogfileparser/cosmors/__init__.py
@@ -1,0 +1,13 @@
+from .fast_cosmors_logfile_parser import (
+    ALL_FIELDS,
+    DATA_FIELDS,
+    METADATA_FIELDS,
+    fast_cosmors_logfile_parser,
+)
+
+__all__ = [
+    "fast_cosmors_logfile_parser",
+    "METADATA_FIELDS",
+    "DATA_FIELDS",
+    "ALL_FIELDS",
+]

--- a/fastlogfileparser/cosmors/fast_cosmors_logfile_parser.py
+++ b/fastlogfileparser/cosmors/fast_cosmors_logfile_parser.py
@@ -1,0 +1,31 @@
+# fast_cosmors_logfile_parser.py
+# a single function meant to retrieve data from cosmors logfiles quickly,
+# using exclusively regular expressions and reading the file only once.
+from fastlogfileparser.generic.iter_patterns import iter_patterns
+from .utils.postprocessing import POSTPROCESSING_FUNCTIONS
+from .utils.regexes import COMPILED_PATTERNS, DATA, METADATA
+
+METADATA_FIELDS = tuple(METADATA.keys())
+DATA_FIELDS = tuple(DATA.keys())
+ALL_FIELDS = DATA_FIELDS + METADATA_FIELDS
+
+
+def fast_cosmors_logfile_parser(
+    target_file: str,
+    get: tuple = ALL_FIELDS,
+    verbose: int = 0,
+):
+    """Parse COSMO-RS Logfile, but Fast-ly
+
+    Args:
+        target_file (str, optional): Logfile path.
+        get (tuple[str]): Fields to retrieve.
+        verbose (int, optional): 0 for silent, 1 for info, 2 for debug. Defaults to 0.
+
+    Returns:
+        dict: kvp of logfile contents, one per job
+    """
+    with open(target_file, "r") as file:
+        logfile_text = file.read()
+    # cosmo-rs does not support composite jobs, but for consistency with other parsers we return as a tuple
+    return (iter_patterns(logfile_text, target_file, COMPILED_PATTERNS, get, POSTPROCESSING_FUNCTIONS, verbose=verbose),)

--- a/fastlogfileparser/cosmors/utils/postprocessing.py
+++ b/fastlogfileparser/cosmors/utils/postprocessing.py
@@ -1,0 +1,10 @@
+from fastlogfileparser.generic.postprocessing import (
+    _str_to_float,
+)
+
+
+POSTPROCESSING_FUNCTIONS = {
+    "area": _str_to_float,
+    "volume": _str_to_float,
+    "energy": _str_to_float,
+}

--- a/fastlogfileparser/cosmors/utils/regexes.py
+++ b/fastlogfileparser/cosmors/utils/regexes.py
@@ -1,0 +1,12 @@
+import re
+
+DATA = {
+    "area": r"  area=\s+(-?\d+\.\d+)",
+    "volume": r"  volume=\s+(-?\d+\.\d+)",
+    "energy": r"  Total energy \+ OC corr\. \[a\.u\.\] =\s+(-?\d+\.\d+)",
+}
+
+METADATA = {}
+
+RETRIEVAL_PATTERNS = {**DATA, **METADATA}
+COMPILED_PATTERNS = {pattern_name: re.compile(pattern) for (pattern_name, pattern) in RETRIEVAL_PATTERNS.items()}

--- a/fastlogfileparser/gaussian/utils/postprocessing.py
+++ b/fastlogfileparser/gaussian/utils/postprocessing.py
@@ -38,6 +38,11 @@ def _mulliken(in_list):
     return out
 
 
+def _nmr(in_list):
+    print([[int(i[0])] + _str_list_to_floats(i[1:]) for i in in_list])
+    return [[int(i[0])] + _str_list_to_floats(i[1:]) for i in in_list]
+
+
 POSTPROCESSING_FUNCTIONS = {
     "cpu_time": _unix_time_to_seconds,
     "wall_time": _unix_time_to_seconds,
@@ -65,4 +70,5 @@ POSTPROCESSING_FUNCTIONS = {
     "dipole_moment_debye": lambda in_list: _str_list_to_floats(in_list[-1]),  # always choose last printing
     "homo_lumo_gap": _hl_gap,
     "beta_homo_lumo_gap": _hl_gap,
+    "nmr_shielding": _nmr,
 }

--- a/fastlogfileparser/gaussian/utils/postprocessing.py
+++ b/fastlogfileparser/gaussian/utils/postprocessing.py
@@ -39,7 +39,6 @@ def _mulliken(in_list):
 
 
 def _nmr(in_list):
-    print([[int(i[0])] + _str_list_to_floats(i[1:]) for i in in_list])
     return [[int(i[0])] + _str_list_to_floats(i[1:]) for i in in_list]
 
 

--- a/fastlogfileparser/gaussian/utils/postprocessing.py
+++ b/fastlogfileparser/gaussian/utils/postprocessing.py
@@ -19,6 +19,13 @@ def _fortran_float_to_float(in_list):
     return _str_to_float(['e'.join(in_list[0])])
 
 
+def _hl_gap(in_list):
+    """Calculates HOMO-LUMO gap from the
+    HOMO and LUMO energies"""
+    print(in_list)
+    return float(in_list[-1][1]) - float(in_list[-1][0])
+
+
 def _mulliken(in_list):
     out = []
     for i in in_list:
@@ -53,5 +60,6 @@ POSTPROCESSING_FUNCTIONS = {
     "mulliken_charges_summed": _mulliken,
     "dipole_au": _fortran_float_to_float,
     "aniso_polarizability_au": _fortran_float_to_float,
-    "dipole_moment_debye": lambda in_list: _str_list_to_floats(in_list[-1])  # always choose last printing
+    "dipole_moment_debye": lambda in_list: _str_list_to_floats(in_list[-1]),  # always choose last printing
+    "homo_lumo_gap": _hl_gap,
 }

--- a/fastlogfileparser/gaussian/utils/postprocessing.py
+++ b/fastlogfileparser/gaussian/utils/postprocessing.py
@@ -21,8 +21,10 @@ def _fortran_float_to_float(in_list):
 
 def _hl_gap(in_list):
     """Calculates HOMO-LUMO gap from the
-    HOMO and LUMO energies"""
-    return float(in_list[-1][1]) - float(in_list[-1][0])
+    HOMO and LUMO energies
+
+    Can be printed multiple times - take the first occurrence"""
+    return float(in_list[0][1]) - float(in_list[0][0])
 
 
 def _mulliken(in_list):
@@ -62,4 +64,5 @@ POSTPROCESSING_FUNCTIONS = {
     "iso_polarizability_au": _fortran_float_to_float,
     "dipole_moment_debye": lambda in_list: _str_list_to_floats(in_list[-1]),  # always choose last printing
     "homo_lumo_gap": _hl_gap,
+    "beta_homo_lumo_gap": _hl_gap,
 }

--- a/fastlogfileparser/gaussian/utils/postprocessing.py
+++ b/fastlogfileparser/gaussian/utils/postprocessing.py
@@ -32,11 +32,21 @@ def _mulliken(in_list):
     for i in in_list:
         inner_out = []
         for row in i.split(sep="\n"):
-            atom_idx, _, mulliken_charge, _ = row.split()
+            atom_idx, _, mulliken_charge = row.split()
             inner_out.append([int(atom_idx), float(mulliken_charge)])
         out.append(inner_out)
     return out
 
+
+# def _mulliken_densities(in_list):
+#     out = []
+#     for i in in_list:
+#         inner_out = []
+#         for row in i.split(sep="\n"):
+#             atom_idx, _, mulliken_charge, spin_density = row.split()
+#             inner_out.append([int(atom_idx), float(mulliken_charge), float(spin_density)])
+#         out.append(inner_out)
+#     return out
 
 def _nmr(in_list):
     return [[int(i[0])] + _str_list_to_floats(i[1:]) for i in in_list]
@@ -63,6 +73,7 @@ POSTPROCESSING_FUNCTIONS = {
     "route_section": lambda in_list: in_list[0],
     "charge_and_multiplicity": _charge_and_multiplicity,
     "mulliken_charges_summed": _mulliken,
+    # "mulliken_charges_spin_densities_summed": _mulliken_densities,
     "dipole_au": _fortran_float_to_float,
     "aniso_polarizability_au": _fortran_float_to_float,
     "iso_polarizability_au": _fortran_float_to_float,

--- a/fastlogfileparser/gaussian/utils/postprocessing.py
+++ b/fastlogfileparser/gaussian/utils/postprocessing.py
@@ -59,6 +59,7 @@ POSTPROCESSING_FUNCTIONS = {
     "mulliken_charges_summed": _mulliken,
     "dipole_au": _fortran_float_to_float,
     "aniso_polarizability_au": _fortran_float_to_float,
+    "iso_polarizability_au": _fortran_float_to_float,
     "dipole_moment_debye": lambda in_list: _str_list_to_floats(in_list[-1]),  # always choose last printing
     "homo_lumo_gap": _hl_gap,
 }

--- a/fastlogfileparser/gaussian/utils/postprocessing.py
+++ b/fastlogfileparser/gaussian/utils/postprocessing.py
@@ -8,6 +8,17 @@ from fastlogfileparser.generic.postprocessing import (
 )
 
 
+def _dipole(in_list):
+    """Gaussian emits this:
+    0.122109D+01
+    which is parsed as this by regex:
+    [('0.118671', '+01'), ('0.118671', '+01')]
+    which we convert to this:
+    1.18671
+    """
+    return _str_to_float(['e'.join(in_list[0])])
+
+
 def _mulliken(in_list):
     out = []
     for i in in_list:
@@ -40,4 +51,5 @@ POSTPROCESSING_FUNCTIONS = {
     "route_section": lambda in_list: in_list[0],
     "charge_and_multiplicity": _charge_and_multiplicity,
     "mulliken_charges_summed": _mulliken,
+    "dipole_au": _dipole,
 }

--- a/fastlogfileparser/gaussian/utils/postprocessing.py
+++ b/fastlogfileparser/gaussian/utils/postprocessing.py
@@ -22,7 +22,6 @@ def _fortran_float_to_float(in_list):
 def _hl_gap(in_list):
     """Calculates HOMO-LUMO gap from the
     HOMO and LUMO energies"""
-    print(in_list)
     return float(in_list[-1][1]) - float(in_list[-1][0])
 
 

--- a/fastlogfileparser/gaussian/utils/postprocessing.py
+++ b/fastlogfileparser/gaussian/utils/postprocessing.py
@@ -8,9 +8,9 @@ from fastlogfileparser.generic.postprocessing import (
 )
 
 
-def _dipole(in_list):
+def _fortran_float_to_float(in_list):
     """Gaussian emits this:
-    0.122109D+01
+    0.122109D+01 (printed in two places, but identical)
     which is parsed as this by regex:
     [('0.118671', '+01'), ('0.118671', '+01')]
     which we convert to this:
@@ -51,5 +51,6 @@ POSTPROCESSING_FUNCTIONS = {
     "route_section": lambda in_list: in_list[0],
     "charge_and_multiplicity": _charge_and_multiplicity,
     "mulliken_charges_summed": _mulliken,
-    "dipole_au": _dipole,
+    "dipole_au": _fortran_float_to_float,
+    "aniso_polarizability_au": _fortran_float_to_float,
 }

--- a/fastlogfileparser/gaussian/utils/postprocessing.py
+++ b/fastlogfileparser/gaussian/utils/postprocessing.py
@@ -53,4 +53,5 @@ POSTPROCESSING_FUNCTIONS = {
     "mulliken_charges_summed": _mulliken,
     "dipole_au": _fortran_float_to_float,
     "aniso_polarizability_au": _fortran_float_to_float,
+    "dipole_moment_debye": lambda in_list: _str_list_to_floats(in_list[-1])  # always choose last printing
 }

--- a/fastlogfileparser/gaussian/utils/regexes.py
+++ b/fastlogfileparser/gaussian/utils/regexes.py
@@ -50,6 +50,7 @@ DATA = {
     ),
     "charge_and_multiplicity": r" Charge = {1,2}(-?\d) Multiplicity = (\d)",
     "dipole_au": r"   Tot        (-?\d+.\d+)D([\+|-]\d+)",
+    "iso_polarizability_au": r"   iso        (-?\d+.\d+)D([\+|-]\d+)",
     "aniso_polarizability_au": r"   aniso      (-?\d+.\d+)D([\+|-]\d+)",
     "dipole_moment_debye": r"    X=\s+(-?\d+.\d+)\s+Y=\s+(-?\d+.\d+)\s+Z=\s+(-?\d+.\d+)",
     "homo_lumo_gap": (

--- a/fastlogfileparser/gaussian/utils/regexes.py
+++ b/fastlogfileparser/gaussian/utils/regexes.py
@@ -49,6 +49,9 @@ DATA = {
         r" APT charges:"
     ),
     "charge_and_multiplicity": r" Charge = {1,2}(-?\d) Multiplicity = (\d)",
+    "dipole_au": (
+        r"   Tot        (-?\d+.\d+)D([\+|-]\d+)"
+    ),
 }
 
 METADATA = {
@@ -61,9 +64,4 @@ METADATA = {
 }
 
 RETRIEVAL_PATTERNS = {**DATA, **METADATA}
-
-# other options:
-# homo-lumo gap, polarizability, dipole moment, APT partial charges, occupancy
-
-
 COMPILED_PATTERNS = {pattern_name: re.compile(pattern) for (pattern_name, pattern) in RETRIEVAL_PATTERNS.items()}

--- a/fastlogfileparser/gaussian/utils/regexes.py
+++ b/fastlogfileparser/gaussian/utils/regexes.py
@@ -56,7 +56,11 @@ DATA = {
     "homo_lumo_gap": (
         r" Alpha  occ\. eigenvalues --[\s+-?\d+.\d+]+?\s+(-?\d+.\d+)\n"
         r" Alpha virt\. eigenvalues --\s+(-?\d+.\d+)"
-    )
+    ),
+    "beta_homo_lumo_gap": (
+        r"  Beta  occ\. eigenvalues --[\s+-?\d+.\d+]+?\s+(-?\d+.\d+)\n"
+        r"  Beta virt\. eigenvalues --\s+(-?\d+.\d+)"
+    ),
 }
 
 METADATA = {

--- a/fastlogfileparser/gaussian/utils/regexes.py
+++ b/fastlogfileparser/gaussian/utils/regexes.py
@@ -61,6 +61,7 @@ DATA = {
         r"  Beta  occ\. eigenvalues --[\s+-?\d+.\d+]+?\s+(-?\d+.\d+)\n"
         r"  Beta virt\. eigenvalues --\s+(-?\d+.\d+)"
     ),
+    "nmr_shielding": r"\s+(\d+)\s+..?\s+Isotropic =\s+(\d+.\d+)\s+Anisotropy =\s+(\d+.\d+)"
 }
 
 METADATA = {

--- a/fastlogfileparser/gaussian/utils/regexes.py
+++ b/fastlogfileparser/gaussian/utils/regexes.py
@@ -49,9 +49,8 @@ DATA = {
         r" APT charges:"
     ),
     "charge_and_multiplicity": r" Charge = {1,2}(-?\d) Multiplicity = (\d)",
-    "dipole_au": (
-        r"   Tot        (-?\d+.\d+)D([\+|-]\d+)"
-    ),
+    "dipole_au": r"   Tot        (-?\d+.\d+)D([\+|-]\d+)",
+    "aniso_polarizability_au": r"   aniso      (-?\d+.\d+)D([\+|-]\d+)",
 }
 
 METADATA = {

--- a/fastlogfileparser/gaussian/utils/regexes.py
+++ b/fastlogfileparser/gaussian/utils/regexes.py
@@ -51,6 +51,7 @@ DATA = {
     "charge_and_multiplicity": r" Charge = {1,2}(-?\d) Multiplicity = (\d)",
     "dipole_au": r"   Tot        (-?\d+.\d+)D([\+|-]\d+)",
     "aniso_polarizability_au": r"   aniso      (-?\d+.\d+)D([\+|-]\d+)",
+    "dipole_moment_debye": r"    X=\s+(-?\d+.\d+)\s+Y=\s+(-?\d+.\d+)\s+Z=\s+(-?\d+.\d+)"
 }
 
 METADATA = {

--- a/fastlogfileparser/gaussian/utils/regexes.py
+++ b/fastlogfileparser/gaussian/utils/regexes.py
@@ -42,12 +42,22 @@ DATA = {
         r"([\s+\d+\s+\d\s+-?\d\.\d\d\s+-?\d\.\d\d\s+-?\d\.\d\d\s+-?\d\.\d\d\s+-?\d\.\d\d\s+-?\d\.\d\d\s+-?\d\.\d\d\s+-?\d\.\d\d\s+-?\d\.\d\d]+)\n"
         r"(?:\s+\d+\s+\d+\s+\d+)?\n"
     ),
+    # "mulliken_charges_densities_summed": (
+    #     r" Mulliken charges and spin densities with hydrogens summed into heavy atoms:\n"
+    #     r"               1          2\n"
+    #     r"((?:\s+\d+\s+[a-zA-Z]{1,3}\s+-?\d+\.\d+\s+-?\d+\.\d+)+)\n"
+    # ),
     "mulliken_charges_summed": (
-        r" Mulliken charges and spin densities with hydrogens summed into heavy atoms:\n"
-        r"               1          2\n"
-        r"((?:\s+\d+\s+[a-zA-Z]{1,3}\s+-?\d+\.\d+\s+-?\d+\.\d+)+)\n"
-        r" APT charges:"
+        r" Mulliken charges with hydrogens summed into heavy atoms:\n"
+        r"\s+1\n"
+        r"((?:\s+\d+\s+[a-zA-Z]{1,3}\s+-?\d+\.\d+)+)\n"
     ),
+    # "mbs_mulliken_charges_summed": (
+    #     r" MBS Mulliken charges with hydrogens summed into heavy atoms:\n"
+    #     r"               1\n"
+    #     r"((?:\s+\d+\s+[a-zA-Z]{1,3}\s+-?\d+\.\d+\s+)+)\n"
+    #     r" \S"
+    # ),
     "charge_and_multiplicity": r" Charge = {1,2}(-?\d) Multiplicity = (\d)",
     "dipole_au": r"   Tot        (-?\d+.\d+)D([\+|-]\d+)",
     "iso_polarizability_au": r"   iso        (-?\d+.\d+)D([\+|-]\d+)",

--- a/fastlogfileparser/gaussian/utils/regexes.py
+++ b/fastlogfileparser/gaussian/utils/regexes.py
@@ -51,7 +51,11 @@ DATA = {
     "charge_and_multiplicity": r" Charge = {1,2}(-?\d) Multiplicity = (\d)",
     "dipole_au": r"   Tot        (-?\d+.\d+)D([\+|-]\d+)",
     "aniso_polarizability_au": r"   aniso      (-?\d+.\d+)D([\+|-]\d+)",
-    "dipole_moment_debye": r"    X=\s+(-?\d+.\d+)\s+Y=\s+(-?\d+.\d+)\s+Z=\s+(-?\d+.\d+)"
+    "dipole_moment_debye": r"    X=\s+(-?\d+.\d+)\s+Y=\s+(-?\d+.\d+)\s+Z=\s+(-?\d+.\d+)",
+    "homo_lumo_gap": (
+        r" Alpha  occ\. eigenvalues --[\s+-?\d+.\d+]+?\s+(-?\d+.\d+)\n"
+        r" Alpha virt\. eigenvalues --\s+(-?\d+.\d+)"
+    )
 }
 
 METADATA = {

--- a/fastlogfileparser/orca/utils/postprocessing.py
+++ b/fastlogfileparser/orca/utils/postprocessing.py
@@ -13,4 +13,5 @@ POSTPROCESSING_FUNCTIONS = {
     "charge_and_multiplicity": _charge_and_multiplicity,
     "energy": _str_to_float,
     "dipole_au": _str_to_float,
+    "t1_diagnostic": _str_to_float,
 }

--- a/fastlogfileparser/orca/utils/postprocessing.py
+++ b/fastlogfileparser/orca/utils/postprocessing.py
@@ -12,4 +12,5 @@ POSTPROCESSING_FUNCTIONS = {
     "route_section": lambda in_list: in_list[0],
     "charge_and_multiplicity": _charge_and_multiplicity,
     "energy": _str_to_float,
+    "dipole_au": _str_to_float,
 }

--- a/fastlogfileparser/orca/utils/regexes.py
+++ b/fastlogfileparser/orca/utils/regexes.py
@@ -10,7 +10,8 @@ DATA = {
     "input_coordinates": r"\|[ \d]{3}>.\w{1,2}[ ]{2,3}([\s+\d+\s+\d+\s+-?\d+\.\d+\s+-?\d+\.\d+\s+-?\d+\.\d+]+)\n",
     "energy": r"FINAL SINGLE POINT ENERGY\s+(-?\d+.\d+)\n",
     "charge_and_multiplicity": r"...> \* xyz (-?\d) (\d)\n",
-    "dipole_au": r"Magnitude \(a.u.\)       :\s+(-?\d+.\d+)\n"
+    "dipole_au": r"Magnitude \(a.u.\)       :\s+(-?\d+.\d+)\n",
+    "t1_diagnostic": r"T1 diagnostic\s+\.\.\.\s+([\d\.]+)\n"
 }
 
 METADATA = {

--- a/fastlogfileparser/orca/utils/regexes.py
+++ b/fastlogfileparser/orca/utils/regexes.py
@@ -11,7 +11,7 @@ DATA = {
     "energy": r"FINAL SINGLE POINT ENERGY\s+(-?\d+.\d+)\n",
     "charge_and_multiplicity": r"...> \* xyz (-?\d) (\d)\n",
     "dipole_au": r"Magnitude \(a.u.\)       :\s+(-?\d+.\d+)\n",
-    "t1_diagnostic": r"T1 diagnostic\s+\.\.\.\s+([\d\.]+)\n"
+    "t1_diagnostic": r"T1 diagnostic\s+\.\.\.\s+([\d\.]+)"
 }
 
 METADATA = {

--- a/fastlogfileparser/orca/utils/regexes.py
+++ b/fastlogfileparser/orca/utils/regexes.py
@@ -10,6 +10,7 @@ DATA = {
     "input_coordinates": r"\|[ \d]{3}>.\w{1,2}[ ]{2,3}([\s+\d+\s+\d+\s+-?\d+\.\d+\s+-?\d+\.\d+\s+-?\d+\.\d+]+)\n",
     "energy": r"FINAL SINGLE POINT ENERGY\s+(-?\d+.\d+)\n",
     "charge_and_multiplicity": r"...> \* xyz (-?\d) (\d)\n",
+    "dipole_au": r"Magnitude \(a.u.\)       :\s+(-?\d+.\d+)\n"
 }
 
 METADATA = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fastlogfileparser"
-version = "1.0.0a7"
+version = "1.0.0"
 authors = [
     { name = "Jackson Burns" },
 ]

--- a/test/cosmors_test.py
+++ b/test/cosmors_test.py
@@ -1,0 +1,21 @@
+import os
+
+import pytest
+
+from fastlogfileparser.cosmors import fast_cosmors_logfile_parser
+
+from .data_check_test import pytest_dep_args
+
+
+@pytest.mark.dependency(**pytest_dep_args)
+def test_fast_cosmors_logfile_parser():
+    """
+    Test cosmors parser
+    """
+
+    file = os.path.join(os.path.dirname(__file__), "data", "id1.cosmo")
+    # note the comma, which returns the only element in the tuple rather than a tuple
+    (result,) = fast_cosmors_logfile_parser(file)
+    assert result.area == 307.84
+    assert result.volume == 461.21
+    assert result.energy == -179.1472514653

--- a/test/gaussian_test.py
+++ b/test/gaussian_test.py
@@ -25,9 +25,10 @@ def test_descriptors():
     """
 
     file = os.path.join(os.path.dirname(__file__), "data", "rxn_233.log")
-    result_1, result_2, result_3 = fast_gaussian_logfile_parser(file)
+    result_1, result_2, _ = fast_gaussian_logfile_parser(file)
     assert result_1.dipole_au == 0.122109e+01
     assert result_2.dipole_au == 0.158789e+01
+    assert result_2.aniso_polarizability_au == 0.112005e+03
     assert result_1.mulliken_charges_summed == [
         [
             [2, -0.022831],

--- a/test/gaussian_test.py
+++ b/test/gaussian_test.py
@@ -26,11 +26,11 @@ def test_descriptors():
 
     file = os.path.join(os.path.dirname(__file__), "data", "rxn_233.log")
     result_1, result_2, _ = fast_gaussian_logfile_parser(file, verbose=1)
-    assert result_1.dipole_au == 0.122109e+01
-    assert result_2.dipole_au == 0.158789e+01
+    assert result_1.dipole_au == 0.122109e01
+    assert result_2.dipole_au == 0.158789e01
     assert result_1.dipole_moment_debye == [-2.2032, 1.3307, -1.7344]
-    assert result_2.aniso_polarizability_au == 0.112005e+03
-    assert result_2.iso_polarizability_au == 0.116915e+03
+    assert result_2.aniso_polarizability_au == 0.112005e03
+    assert result_2.iso_polarizability_au == 0.116915e03
     assert result_2.homo_lumo_gap == -0.03696 - -0.33782
     assert result_2.beta_homo_lumo_gap == -0.05882 - -0.35120
     assert result_1.mulliken_charges_summed == [
@@ -490,6 +490,46 @@ def test_fast_gaussian_logfile_parser_2():
     assert job.normal_termination is False
     assert job.charge_and_multiplicity == [0, 1]
     assert len(job.scf) == job.number_of_optimization_steps
+
+
+@pytest.mark.dependency(**pytest_dep_args)
+def test_fast_gaussian_logfile_parser_nmr():
+    """
+    Test parser using a gaussian log file with NMR shielding values
+    """
+
+    file = os.path.join(os.path.dirname(__file__), "data", "237500.log")
+    job = fast_gaussian_logfile_parser(file, verbose=2)[0]
+    assert job.nmr_shielding == [
+        [1, 166.7741, 37.9465],
+        [2, 190.8511, 117.122],
+        [3, 45.6783, 64.2935],
+        [4, 68.8624, 388.9648],
+        [5, 195.7116, 113.3207],
+        [6, 130.0634, 51.9268],
+        [7, 172.7552, 56.8353],
+        [8, 179.7469, 40.1276],
+        [9, 150.7909, 83.5181],
+        [10, 235.2829, 54.4991],
+        [11, 151.4629, 61.3373],
+        [12, 151.1384, 59.9659],
+        [13, 29.4065, 9.5882],
+        [14, 29.0305, 10.2075],
+        [15, 28.5521, 6.2598],
+        [16, 28.4858, 12.913],
+        [17, 26.8329, 7.2528],
+        [18, 29.0884, 7.2887],
+        [19, 30.1682, 8.3255],
+        [20, 30.9149, 12.3327],
+        [21, 31.2904, 13.3682],
+        [22, 30.3846, 7.9497],
+        [23, 29.2111, 9.8211],
+        [24, 29.5067, 11.2524],
+        [25, 29.6968, 9.456],
+        [26, 29.5085, 10.5683],
+        [27, 29.6833, 7.9136],
+        [28, 29.1883, 8.2428],
+    ]
 
 
 @pytest.mark.dependency(**pytest_dep_args)

--- a/test/gaussian_test.py
+++ b/test/gaussian_test.py
@@ -25,11 +25,12 @@ def test_descriptors():
     """
 
     file = os.path.join(os.path.dirname(__file__), "data", "rxn_233.log")
-    result_1, result_2, _ = fast_gaussian_logfile_parser(file)
+    result_1, result_2, _ = fast_gaussian_logfile_parser(file, verbose=1)
     assert result_1.dipole_au == 0.122109e+01
     assert result_2.dipole_au == 0.158789e+01
     assert result_1.dipole_moment_debye == [-2.2032, 1.3307, -1.7344]
     assert result_2.aniso_polarizability_au == 0.112005e+03
+    assert result_2.homo_lumo_gap == 0.30695
     assert result_1.mulliken_charges_summed == [
         [
             [2, -0.022831],

--- a/test/gaussian_test.py
+++ b/test/gaussian_test.py
@@ -30,6 +30,7 @@ def test_descriptors():
     assert result_2.dipole_au == 0.158789e+01
     assert result_1.dipole_moment_debye == [-2.2032, 1.3307, -1.7344]
     assert result_2.aniso_polarizability_au == 0.112005e+03
+    assert result_2.iso_polarizability_au == 0.116915e+03
     assert result_2.homo_lumo_gap == 0.30695
     assert result_1.mulliken_charges_summed == [
         [

--- a/test/gaussian_test.py
+++ b/test/gaussian_test.py
@@ -31,7 +31,8 @@ def test_descriptors():
     assert result_1.dipole_moment_debye == [-2.2032, 1.3307, -1.7344]
     assert result_2.aniso_polarizability_au == 0.112005e+03
     assert result_2.iso_polarizability_au == 0.116915e+03
-    assert result_2.homo_lumo_gap == 0.30695
+    assert result_2.homo_lumo_gap == -0.03696 - -0.33782
+    assert result_2.beta_homo_lumo_gap == -0.05882 - -0.35120
     assert result_1.mulliken_charges_summed == [
         [
             [2, -0.022831],

--- a/test/gaussian_test.py
+++ b/test/gaussian_test.py
@@ -28,6 +28,7 @@ def test_descriptors():
     result_1, result_2, _ = fast_gaussian_logfile_parser(file)
     assert result_1.dipole_au == 0.122109e+01
     assert result_2.dipole_au == 0.158789e+01
+    assert result_1.dipole_moment_debye == [-2.2032, 1.3307, -1.7344]
     assert result_2.aniso_polarizability_au == 0.112005e+03
     assert result_1.mulliken_charges_summed == [
         [

--- a/test/gaussian_test.py
+++ b/test/gaussian_test.py
@@ -19,14 +19,16 @@ def test_duplicated_frequencies_handling():
 
 
 @pytest.mark.dependency(**pytest_dep_args)
-def test_mulliken_charges():
+def test_descriptors():
     """
-    Mulliken charges summed into heavy atoms.
+    Various molecular and atomic descriptors.
     """
 
     file = os.path.join(os.path.dirname(__file__), "data", "rxn_233.log")
-    result, _, _ = fast_gaussian_logfile_parser(file)
-    assert result.mulliken_charges_summed == [
+    result_1, result_2, result_3 = fast_gaussian_logfile_parser(file)
+    assert result_1.dipole_au == 0.122109e+01
+    assert result_2.dipole_au == 0.158789e+01
+    assert result_1.mulliken_charges_summed == [
         [
             [2, -0.022831],
             [3, 0.023347],

--- a/test/orca_test.py
+++ b/test/orca_test.py
@@ -78,4 +78,4 @@ def test_fast_orca_logfile_parser_dlpno():
         [1.116944, 1.003499, 1.262404],
         [1.645021, 1.795278, -0.262281],
     ]
-    assert result.t1_diagnostic == 0.020468528   
+    assert result.t1_diagnostic == 0.020468528

--- a/test/orca_test.py
+++ b/test/orca_test.py
@@ -60,6 +60,7 @@ def test_fast_orca_logfile_parser_dlpno():
     assert result.route_section == "uHF UNO DLPNO-CCSD(T)-F12D cc-pvtz-f12 def2/J cc-pvqz/c cc-pvqz-f12-cabs RIJCOSX NormalSCF NormalPNO"
     assert result.run_time == 356.0
     assert result.charge_and_multiplicity == [0, 2]
+    assert result.dipole_au == 1.03126
     assert result.input_coordinates == [
         [-1.516928, -1.007427, -0.400551],
         [-1.471551, 0.245216, 0.33273],

--- a/test/orca_test.py
+++ b/test/orca_test.py
@@ -46,6 +46,7 @@ def test_fast_orca_logfile_parser():
         [0.757108, 0.032206, -1.19073],
         [0.644543, -3.834457, -1.132202],
     ]
+    assert result.t1_diagnostic == 0.017012200
 
 
 @pytest.mark.dependency(**pytest_dep_args)
@@ -77,3 +78,4 @@ def test_fast_orca_logfile_parser_dlpno():
         [1.116944, 1.003499, 1.262404],
         [1.645021, 1.795278, -0.262281],
     ]
+    assert result.t1_diagnostic == 0.020468528   


### PR DESCRIPTION
This PR and its pair on `databases` (https://github.com/QuantumPioneer/databases/pull/4) will be the first release of the code surrounding the data itself, though not the data itself which will be available with the eventual publication.

This PR resolves #5 by implementing the following:

For ORCA:

- [x] dipoles

For Gaussian, these will almost definitely be added:

- [x] electric dipole moment
- [x] polarizibility

and these _might_ be added:
- [ ] NPA partial charges
- [ ] NMR shielding constants (istotropic line)
- [x] HOMO-LUMO gap, up to some number
- [x] ~~multipole moments, up to quadrupole (?)~~ just got the dipole