### PR TITLE
Fixes Mulliken charges and route section parsing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, release/*]
   workflow_dispatch:
 
 concurrency:

--- a/fastlogfileparser/gaussian/utils/postprocessing.py
+++ b/fastlogfileparser/gaussian/utils/postprocessing.py
@@ -32,7 +32,7 @@ def _mulliken(in_list):
     for i in in_list:
         inner_out = []
         for row in i.split(sep="\n"):
-            atom_idx, _, mulliken_charge = row.split()
+            atom_idx, _, mulliken_charge, *_ = row.split()
             inner_out.append([int(atom_idx), float(mulliken_charge)])
         out.append(inner_out)
     return out

--- a/fastlogfileparser/gaussian/utils/preprocessing.py
+++ b/fastlogfileparser/gaussian/utils/preprocessing.py
@@ -26,7 +26,7 @@ def crush_ginc_block(opened_file):
         elif in_route_section:
             # check if block is over
             if (
-                " ----------------------------------------------------------------------\n"
+                " " + "-" * (len(line) - 2) + "\n"
                 == line
             ):
                 in_route_section = False

--- a/fastlogfileparser/gaussian/utils/regexes.py
+++ b/fastlogfileparser/gaussian/utils/regexes.py
@@ -48,9 +48,9 @@ DATA = {
     #     r"((?:\s+\d+\s+[a-zA-Z]{1,3}\s+-?\d+\.\d+\s+-?\d+\.\d+)+)\n"
     # ),
     "mulliken_charges_summed": (
-        r" Mulliken charges with hydrogens summed into heavy atoms:\n"
-        r"\s+1\n"
-        r"((?:\s+\d+\s+[a-zA-Z]{1,3}\s+-?\d+\.\d+)+)\n"
+        r" Mulliken charges(?: and spin densities)? with hydrogens summed into heavy atoms:\n"
+        r"\s+1(?:\s+2)?\n"
+        r"((?:\s+\d+\s+[a-zA-Z]{1,3}\s+-?\d+\.\d+(?:\s+-?\d+\.\d+)?)+)\n"
     ),
     # "mbs_mulliken_charges_summed": (
     #     r" MBS Mulliken charges with hydrogens summed into heavy atoms:\n"

--- a/test/orca_test.py
+++ b/test/orca_test.py
@@ -78,4 +78,4 @@ def test_fast_orca_logfile_parser_dlpno():
         [1.116944, 1.003499, 1.262404],
         [1.645021, 1.795278, -0.262281],
     ]
-    assert result.t1_diagnostic == 0.020468528   
+    assert result.t1_diagnostic == 0.020468528


### PR DESCRIPTION
- Parses summed Mulliken charges even when they are logged together with spin densities
- Correctly handles the following route section:

```
 -------------------------------------------------------
 #opt=(calcall,maxcycle=128,noeig,nomicro,cartesian) pm7
 -------------------------------------------------------
```