### PR TITLE
Adds Natural Population Analysis (NPA) charge parsing for Gaussian log files

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ job_1, job_2, job_3 = fglp(FNAME, get=("gibbs", "scf"))
 | Input xyz coords | `xyz` | list[list[float]] | 1/step/job |
 | Standardized forces | `std_forces` | list[list[float]] | 1/step/job |
 | Mulliken Charges (Summed into Heavy) | `mulliken_charges_summed` | list[list[float]] | 2/job |
+| Natural Population Analysis Charges | `npa_charges` | list[list[int, float]] | 1/job |
 | Charge and Multiplicity | `charge_and_multiplicity` | list[int] | 1/job |
 | Number of Atoms $^2$ | `number_of_atoms` | int | 1/job |
 | Number of Optimization Steps $^2$ | `number_of_optimization_steps` | int | 1/job |

--- a/fastlogfileparser/gaussian/utils/postprocessing.py
+++ b/fastlogfileparser/gaussian/utils/postprocessing.py
@@ -52,6 +52,15 @@ def _nmr(in_list):
     return [[int(i[0])] + _str_list_to_floats(i[1:]) for i in in_list]
 
 
+def _npa(in_list):
+    assert len(in_list) == 1
+    out = []
+    for row in in_list[0].split(sep="\n"):
+        _, atom_idx, npa_charge, *_ = row.split()
+        out.append([int(atom_idx), float(npa_charge)])
+    return out
+
+
 POSTPROCESSING_FUNCTIONS = {
     "cpu_time": _unix_time_to_seconds,
     "wall_time": _unix_time_to_seconds,
@@ -81,4 +90,5 @@ POSTPROCESSING_FUNCTIONS = {
     "homo_lumo_gap": _hl_gap,
     "beta_homo_lumo_gap": _hl_gap,
     "nmr_shielding": _nmr,
+    "npa_charges": _npa,
 }

--- a/fastlogfileparser/gaussian/utils/regexes.py
+++ b/fastlogfileparser/gaussian/utils/regexes.py
@@ -71,7 +71,14 @@ DATA = {
         r"  Beta  occ\. eigenvalues --[\s+-?\d+.\d+]+?\s+(-?\d+.\d+)\n"
         r"  Beta virt\. eigenvalues --\s+(-?\d+.\d+)"
     ),
-    "nmr_shielding": r"\s+(\d+)\s+..?\s+Isotropic =\s+(\d+.\d+)\s+Anisotropy =\s+(\d+.\d+)"
+    "nmr_shielding": r"\s+(\d+)\s+..?\s+Isotropic =\s+(\d+.\d+)\s+Anisotropy =\s+(\d+.\d+)",
+    "npa_charges": (
+        r"             Natural    ---------------------------------------------\n"
+        r"  Atom No    Charge        Core      Valence    Rydberg      Total\n"
+        r" --------------------------------------------------------------------\n"
+        r"((?:\s+[A-Z]{1,3}\s+\d+\s+-?\d+\.\d+\s+\d+\.\d+\s+\d+\.\d+\s+\d+\.\d+\s+\d+\.\d+)+)\n"
+        r" ====================================================================\n"
+    ),
 }
 
 METADATA = {

--- a/test/gaussian_test.py
+++ b/test/gaussian_test.py
@@ -493,14 +493,14 @@ def test_fast_gaussian_logfile_parser_2():
 
 
 @pytest.mark.dependency(**pytest_dep_args)
-def test_fast_gaussian_logfile_parser_nmr():
+def test_fast_gaussian_logfile_parser_nmr_shielding_and_npa_charges():
     """
-    Test parser using a gaussian log file with NMR shielding values
+    Test parser using a gaussian log file with NMR shielding and NPA charge values
     """
 
     file = os.path.join(os.path.dirname(__file__), "data", "237500.log")
-    job = fast_gaussian_logfile_parser(file, verbose=2)[0]
-    assert job.nmr_shielding == [
+    job_1, job_2 = fast_gaussian_logfile_parser(file, verbose=2)
+    assert job_1.nmr_shielding == [
         [1, 166.7741, 37.9465],
         [2, 190.8511, 117.122],
         [3, 45.6783, 64.2935],
@@ -529,6 +529,36 @@ def test_fast_gaussian_logfile_parser_nmr():
         [26, 29.5085, 10.5683],
         [27, 29.6833, 7.9136],
         [28, 29.1883, 8.2428],
+    ]
+    assert job_2.npa_charges == [
+        [1, -0.41132],
+        [2, -0.70744],
+        [3, 1.00048],
+        [4, -0.68603],
+        [5, -0.61385],
+        [6, -0.06620],
+        [7, -0.28705],
+        [8, -0.43138],
+        [9, -0.03620],
+        [10, -0.57396],
+        [11, -0.40799],
+        [12, -0.40888],
+        [13, 0.21558],
+        [14, 0.20426],
+        [15, 0.22473],
+        [16, 0.41395],
+        [17, 0.22480],
+        [18, 0.21009],
+        [19, 0.25820],
+        [20, 0.23854],
+        [21, 0.22533],
+        [22, 0.20197],
+        [23, 0.21573],
+        [24, 0.21262],
+        [25, 0.17742],
+        [26, 0.21304],
+        [27, 0.17587],
+        [28, 0.21767],
     ]
 
 


### PR DESCRIPTION
## Summary
This PR adds support for parsing Natural Population Analysis (NPA) charges from Gaussian log files, expanding the parser's capabilities to extract atomic charge information using the NPA method.

## Changes Made
- **New parsing functionality**: Added regex pattern to extract NPA charge data from Gaussian log files
- **Postprocessing support**: Implemented `_npa()` function to process raw NPA data into structured format
- **Documentation update**: Added NPA charges to the README.md feature list
- **Test coverage**: Extended existing test to verify NPA charge parsing with real data

## Technical Details
- **Data format**: NPA charges are returned as `list[list[int, float]]` where each inner list contains `[atom_index, npa_charge]`
- **Availability**: 1 per job (unlike Mulliken charges which are 2 per job)
- **Integration**: Seamlessly integrated with existing Gaussian parser infrastructure

## Files Modified
- `fastlogfileparser/gaussian/utils/regexes.py` - Added NPA charge regex pattern
- `fastlogfileparser/gaussian/utils/postprocessing.py` - Added NPA postprocessing function
- `test/gaussian_test.py` - Extended test coverage for NPA charges
- `README.md` - Updated feature documentation

## Testing
- Extended existing NMR test to include NPA charge validation
- Test uses real Gaussian log file (`237500.log`) with 28 atoms
- Verifies correct parsing of atom indices and charge values

This enhancement maintains backward compatibility while adding valuable charge analysis capabilities to the FastLogfileParser library.